### PR TITLE
Make Update() sleep for 100ms to reduce CPU usage due to VRCFT constantly checking if the thread is alive

### DIFF
--- a/ETVRTrackingModule.cs
+++ b/ETVRTrackingModule.cs
@@ -37,7 +37,7 @@ namespace ETVRTrackingModule
 
         public override void Update()
         {
-            Thread.Sleep(0);
+            Thread.Sleep(100);
         }
     }
 }


### PR DESCRIPTION
This issue was mentioned by Ramesthegeneric. Thank you! 

It turns out that VRCFT is constantly checking if the module's thread is still alive by repeatedly calling Update() on it. We don't make use of Update() as we make sure everything is up-to-date on a message-to-message basis. As soon as we receive a new OSC message, we recalculate and update required data. 

With that in mind, Update() used Thread.sleep(0), basically giving the control back right after it was called, causing VRCFT to call it again and again. This led to high CPU usage. Setting the update to sleep for 100 ms fixes that. 